### PR TITLE
Accommodates new package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ References:
 
 ## Usage
 
-Require `supertest-session` and pass in the test application:
+Require `supertest-session-as-promised` and pass in the test application:
 
-    var Session = require('supertest-session')({
+    var Session = require('supertest-session-as-promised')({
       app: require('../../path/to/app')
     });
 
 You can set environmental variables by including an `envs` object:
 
-    var Session = require('supertest-session')({
+    var Session = require('supertest-session-as-promised')({
       app: require('../../path/to/app'),
       envs: { NODE_ENV: 'development' }
     });

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Session wrapper around supertest; forked to use [supertest-as-promised](https://github.com/WhoopInc/supertest-as-promised).
 
 [![Build
-Status](https://travis-ci.org/rjz/supertest-session.svg?branch=master)](https://travis-ci.org/rjz/supertest-session)
+Status](https://travis-ci.org/shaunc/supertest-session-as-promised.svg?branch=master)](https://travis-ci.org/shaunc/supertest-session-as-promised)
 [![Coverage
-Status](https://coveralls.io/repos/rjz/supertest-session/badge.png)](https://coveralls.io/r/rjz/supertest-session)
+Status](https://coveralls.io/repos/shaunc/supertest-session-as-promised/badge.png)](https://coveralls.io/r/shaunc/supertest-session-as-promised)
 
 References:
 


### PR DESCRIPTION
This change:
- replaces a few instances of `require('supertest-session')` in readme
- points README badges to `shaunc/supertest-session-as-promised`

Still to-do:
- [ ] ensure travis and coveralls are available for `shaunc/supertest-session-as-promised`
- [ ] update `.coveralls.yml` with correct repo token
